### PR TITLE
【サーバーサイド】商品詳細機能

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -3,12 +3,19 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 // ヘッダー部分後ほど削除
-
+.header {
+  text-align: center;
+  &__logo {
+    width: 185px;
+    height: 49px;
+    line-height: 49px;
+    margin: 40px 0 0;
+  }
+}
 // ここから詳細画面記述
 .main{
   background-color: #f8f8f8;
   height: 100%;
-  margin-top: 100px;
 }
   .showmain{
     padding: 40px;
@@ -29,6 +36,46 @@
         .itemBox{
           background-color: #fff;
           padding: 24px 40px 40px;
+          &__edit-btn{
+            font-size: 24px;
+            line-height: 60px;
+            display: block;
+            background: #d3d3d3;
+            color: #fff;
+            text-align: center;
+            font-weight: 600;
+            transition: all ease-out .3s;
+            touch-action: manipulation;
+            text-decoration: none;
+          }
+          &__delete-btn{
+            font-size: 24px;
+            line-height: 60px;
+            display: block;
+            margin-top: 16px;
+            margin-bottom: 20px;
+            background: #ea352d;
+            color: #fff;
+            text-align: center;
+            font-weight: 600;
+            transition: all ease-out .3s;
+            touch-action: manipulation;
+            text-decoration: none;
+          }
+          &__next-btn{
+            font-size: 24px;
+            line-height: 60px;
+            display: block;
+            margin-top: 16px;
+            background: #ea352d;
+            color: #fff;
+            text-align: center;
+            font-weight: 600;
+            transition: all ease-out .3s;
+            touch-action: manipulation;
+            margin-bottom: 40px;
+            text-decoration: none;
+          }
           &__name{
             text-align: center;
             font-weight: bold;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_current_user_items,only:[:p_exhibiting,:p_soldout]
   before_action :set_user,only:[:p_exhibiting,:p_soldout]
-  before_action :set_item, only:[:show, :destroy, :edit, :update, :purchase, :payment]
+  # before_action :set_item, only:[:show, :destroy, :edit, :update, :purchase, :payment]
 
 
   def index
@@ -34,6 +34,10 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
+    @grandchild = Category.find(@item.category_id)
+    @child = @grandchild.parent
+    @parent = @child.parent
   end
 
   def edit

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -2,8 +2,10 @@
 - @item.each do |item|
   .product__body__lists__list
     .product__body__lists__list__list-img
-      = image_tag item.images[0].image.url, class: "product__body__lists__list__list-img__image"
-      - if item.buyer_id == 1
+    - item.images.each_with_index do |image, index|
+      - if index == 0
+        = link_to image_tag("#{item.images.first.image}", width: '200', height: '200'), item_path(item.id), class: "product__body__lists__list__list-img__image" 
+          - if item.buyer_id.present?
         .sold-tag
           .sold-tag__title sold out
     .product__body__lists__list__detail

--- a/app/views/items/_men.html.haml
+++ b/app/views/items/_men.html.haml
@@ -2,8 +2,10 @@
 - @mencategory.each do |item|
   .product__body__lists__list
     .product__body__lists__list__list-img
-      = image_tag item.images[0].image.url, class: "product__body__lists__list__list-img__image"
-      - if item.buyer_id == 1
+    - item.images.each_with_index do |image, index|
+      - if index == 0
+        = link_to image_tag("#{image.image.url}", width: '200', height: '200'), item_path(item.id), class: "product__body__lists__list__list-img__image" 
+          - if item.buyer_id.present?
         .sold-tag
           .sold-tag__title sold out
     .product__body__lists__list__detail

--- a/app/views/items/_women.html.haml
+++ b/app/views/items/_women.html.haml
@@ -2,8 +2,10 @@
 - @womencategory.each do |item|
   .product__body__lists__list
     .product__body__lists__list__list-img
-      = image_tag item.images[0].image.url, class: "product__body__lists__list__list-img__image"
-      - if item.buyer_id == 1
+    - item.images.each_with_index do |image, index|
+      - if index == 0
+        = link_to image_tag("#{image.image.url}", width: '200', height: '200'), item_path(item.id), class: "product__body__lists__list__list-img__image" 
+          - if item.buyer_id.present?
         .sold-tag
           .sold-tag__title sold out
     .product__body__lists__list__detail

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,5 @@
+.header
+  = link_to image_tag("logo.png", class:"header__logo"), "/"
 .main
   .showmain
     .contentLeft
@@ -5,67 +7,72 @@
       .topcontent
         .itemBox
           %h2.itemBox__name
-            sampletext
+            = @item.name
           .itemBox__body
             %ul.itemBox__body__image
-              %li.itemBox__body__image__mainimage
-                = image_tag src="apple.png", size: "560x346"
-                %ul.itemBox__body__image__mainimage__subimage
-                  %li.itemBox__body__image__mainimage__subimage__subimagebody
-                    = image_tag src="banana.jpg", size: "130x100"
-                  %li.itemBox__body__image__mainimage__subimage__subimagebody
-                    = image_tag src="banana.jpg", size: "130x100"
-                  %li.itemBox__body__image__mainimage__subimage__subimagebody
-                    = image_tag src="banana.jpg", size: "130x100"
+              - @item.images.first(1).each do |image|          
+                %li.itemBox__body__image__mainimage
+                  = image_tag image.image_url, size: "560x346"
+            %ul.itemBox__body__image__mainimage__subimage
+              - @item.images.each do |image|
+                %li.itemBox__body__image__mainimage__subimage__subimagebody
+                  = image_tag image.image_url, size: "130x100"
           .itemBox__price
             %span.itemBox__price__pricemain
-              ¥20000
+              ¥
+              = @item.price
             .itemBox__price__price-detail
-              %span.itemBox__price-detail__placetag1
+              %span
                 （税込み）
-              %span.itemBox__price-detail__placetag2
+              %span
                 送料込み
           .itemBox__itemDteil
-            親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰を打っていしまい
-
+            = @item.description
           .itemBox__table
             %table.itemBox__table--main-table
               %tbody
                 %tr
                   %th.itemBox__table--main-table--tabletitle 出品者 
-                  %td.itemBox__table--main-table--tableinfo hoge
+                  %td.itemBox__table--main-table--tableinfo 
+                    = @item.seller.nickname
                 %tr
                   %th.itemBox__table--main-table--tabletitle カテゴリー
                   %td.itemBox__table--main-table--tableinfo
                     = link_to item_path, class: "itemBox__table--main-table--tableinfo--tableinfotag" do
-                      メンズ 
+                      = @parent.name
                     %br
                     = link_to item_path, class: "itemBox__table--main-table--tableinfo--tableinfotag" do
-                      ジャケット/アウター
+                      = @child.name
                     %br
                     = link_to item_path, class: "itemBox__table--main-table--tableinfo--tableinfotag" do
-                      ノーカラージャケット
+                      = @grandchild.name
                 %tr
                   %th.itemBox__table--main-table--tabletitle ブランド
-                  %td.itemBox__table--main-table--tableinfo coach
-                %tr
-                  %th.itemBox__table--main-table--tabletitle 商品のサイズ
-                  %td.itemBox__table--main-table--tableinfo L
+                  %td.itemBox__table--main-table--tableinfo
+                    = @item.brand.name
                 %tr
                   %th.itemBox__table--main-table--tabletitle 商品の状態
-                  %td.itemBox__table--main-table--tableinfo 新品/未使用
+                  %td.itemBox__table--main-table--tableinfo 
+                    = @item.status.name
                 %tr
                   %th.itemBox__table--main-table--tabletitle 配送料の負担
-                  %td.itemBox__table--main-table--tableinfo 着払い（購入者負担）
+                  %td.itemBox__table--main-table--tableinfo 
+                    = @item.cost.name
                 %tr
                   %th.itemBox__table--main-table--tabletitle 発送元の地域
                   %td.itemBox__table--main-table--tableinfo
                     = link_to item_path, class: "itemBox__table--main-table--tableinfo--tableinfotag" do
-                      青森県
+                      = @item.prefecture.name
                 %tr
                   %th.itemBox__table--main-table--tabletitle 発送の目安
-                  %td.itemBox__table--main-table--tableinfo 1-2日で発送
-
+                  %td.itemBox__table--main-table--tableinfo 
+                    =@item.days.name
+          - if user_signed_in?
+            - if user_signed_in? && current_user.id == @item.seller_id
+              = link_to "この商品を編集する", edit_item_path(@item), class: "itemBox__edit-btn"
+              = link_to "この商品を削除する", item_path(@item.id), method: :delete, data: {confirm: "削除すると二度と復活できません、本当に削除しますか？"}, class: "itemBox__delete-btn"
+            - elsif @item.buyer_id == nil
+              = link_to "購入画面に進む", item_path(@item), class: "itemBox__next-btn" 
       %ul.links 
         %li.links__left
           商品
@@ -76,10 +83,9 @@
         %li.links__right
           = link_to item_path, class: "links__right--rightpath" do
             =icon('fa', 'angle-right')
-            %span 後の商品
-      
+            %span 後の商品      
       .relatedItems
-        = link_to item_path, class: "relatedItems__Itemsinfo" do
-          メンズをもっと見る
+        = link_to "/" , class: "relatedItems__Itemsinfo" do
+          トップページに戻る
 
    


### PR DESCRIPTION
# What
商品詳細機能一覧
ログアウト状態でも商品詳細ページを見ることができる。
出品者にしか商品の編集・削除リンクが踏めないようになっている。
出品者以外にしか商品購入のリンクが踏めないようになっている。

# Why
商品詳細機能は必須機能のため

出品者ログイン画面
[![Image from Gyazo](https://i.gyazo.com/0e313f3a40ee03ad7f2cdf9a6259c64d.png)](https://gyazo.com/0e313f3a40ee03ad7f2cdf9a6259c64d)

出品者以外の画面表示
[![Image from Gyazo](https://i.gyazo.com/adaf6bce2e6fbaeb39354ce67dae40b3.jpg)](https://gyazo.com/adaf6bce2e6fbaeb39354ce67dae40b3)

ログアウト状態画面
[![Image from Gyazo](https://i.gyazo.com/1f00ae4b5e6391d9d4f20482cf0a2b30.png)](https://gyazo.com/1f00ae4b5e6391d9d4f20482cf0a2b30)