### PR TITLE
【マークアップ】ユーザーマイページ

### DIFF
--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,3 +1,4 @@
+-# クレジットカード作成
 = render "layouts/header"
 .mypage-main
   .mypage-main__left

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,3 +1,4 @@
+-# クレジットカード表示
 = render "layouts/header"
 .mypage-main
   .mypage-main__left

--- a/app/views/users/_options.html.haml
+++ b/app/views/users/_options.html.haml
@@ -1,3 +1,4 @@
+-# マイページの左部分
 %nav.mypage-main__left__nav
   %h3.mypage-main__left__nav__head マイページ
   %ul.mypage-main__left__list
@@ -17,4 +18,3 @@
       = link_to "ログアウト", user_path(current_user), class: "mypage-main__left__nav__list__item"
     %li
       = link_to "出品確認", images_path(current_user), class: "mypage-main__left__nav__list__item"
-

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,4 @@
+-# ログアウト
 = render "layouts/header"
 .mypage-main
   .mypage-main__left


### PR DESCRIPTION
# What
ユーザーマイページに以下を追加。マイページ上の左側に常に「マイページの選択肢」があり、左部分に内容が表示される、
*作成の都合上、マイページを作成した後にmasterにmergeしたため、差分が表示されない。よって、SCSSとHAMLをスクリーンショットで提出する。

1.  ログアウトページ/ログアウト機能
- view>users>show.html.haml(ログアウト関連)
https://gyazo.com/3e72bcf2b89bc67f7707ac2af54cc8ff
- view>users>_optinos.html.haml(マイページの選択肢)
https://gyazo.com/c167c1f27e55869762e3009229f2e295
- ログアウト関連とマイページ選択肢のscss
https://gyazo.com/9977b2ca86a94100f6e66b8ad0d59818
-　ページ画像
https://gyazo.com/43ab09b711016160aa186d436b27e343
2. クレジットカード登録機能(カードは一枚のみ表示のため、削除後に改めて登録可能)
- view>cards>new.html.haml(カード登録)
https://gyazo.com/1df9605d22c8b9b1e7b057cf67f7c18e
- view>cards>show.html.haml(カード表示)
https://gyazo.com/7a4f69288e4bc8aca938b3cc64f3937e
- カード登録のscss
https://gyazo.com/e6efe658b0f5341811dd98d60e4b7d6d
- ページ画像
https://gyazo.com/c6970bd690e41ee6c85ec8657f302be8
https://gyazo.com/b8ad3860ae951373135ffe8d2a4f6077

# Why
個人の情報を管理するページが必要であるため。